### PR TITLE
Override the ajax_facets_buttons property for Drupal.ajax_facets glob…

### DIFF
--- a/template.php
+++ b/template.php
@@ -234,7 +234,15 @@ function NNELS_CALS_v001_preprocess_block(&$vars) {
                 'Drupal.behaviors.nnelsSearchWithinSearch = {
                         attach: function (context, settings) {
                                 if (Drupal.ajax_facets) {
+
+                                        /*
+                                        Set certain globals in our favour.
+                                        We need paged results and the Reset Facet link block active,
+                                        setting ajax_facets_buttons to hide that fact lets use both features.
+                                        */
+
                                         Drupal.ajax_facets.force_update_results = true;
+                                        Drupal.ajax_facets.ajax_facets_buttons = false;
                                         jQuery("input#edit-submit-repository-search").once().click(function () {
                                                 Drupal.ajax_facets.sendAjaxQuery({
                                                         pushStateNeeded: true,


### PR DESCRIPTION
…ally, otherwise we don't get paged results from queries hitting ajax/refresh route and can run server out of memory for rendering large (> 4000 items) result sets.

Signed-off-by: Jonathan Schatz <jonathan.schatz@bc.libraries.coop>